### PR TITLE
 Add min Q2 > 10 PHPythia6 config

### DIFF
--- a/Generators/phpythia6_ep_MinQ2_10.cfg
+++ b/Generators/phpythia6_ep_MinQ2_10.cfg
@@ -1,0 +1,125 @@
+roots   0       #COM Energy
+proj    e-      #Electron as projectile
+targ    p       #Proton as target
+frame   3MOM    #3-momentum as frame specify initial beam energies
+p1	1 0.    #e- px
+p1	2 0.    #e- py
+p1	3 -10.  #e- pz
+p2	1 0.    #p px
+p2	2 0.	#p py
+p2	3 250.	#p pz
+msel    2
+mstp    14 30
+mstp    15 0
+mstp    16 1
+mstp    17 4
+mstp    18 3
+mstp    19 1
+mstp    20 0
+mstp    32 8
+mstp    38 4
+#mstp    51 10050 #Certain PDF library required...default is used temporarily
+#mstp    52 2	  #Certain PDF library required...default is used temporarily
+mstp    53 3
+mstp    54 1
+mstp    55 5
+mstp    56 1
+mstp    57 1
+mstp    58 5
+mstp    59 1
+mstp    60 7
+mstp    61 2
+mstp    71 1
+mstp    81 0
+mstp    82 0
+mstp    91 1
+mstp    92 3
+mstp    93 1
+mstp    101 3
+mstp    102 1
+mstp    111 1
+mstp    121 0
+mstp    127 1
+
+parp    13 1
+parp    18 0.40
+parp    81 1.9
+parp    89 1800
+parp    90 0.16
+parp    91 0.40  // intrinsic kt value
+parp    93 5.
+parp    99 0.40
+parp    100 5
+parp    102 0.28
+parp    103 1.0
+parp    104 0.8
+parp    111 2.
+parp    161 3.00
+parp    162 24.6
+parp    163 18.8
+parp    164 11.5
+parp    165 0.47679
+parp    166 0.67597
+
+mstj	1 1      // independent fragmentation
+mstj	12 1
+mstj	45 5
+
+mstu	16 2
+mstu	112 5
+mstu	113 5
+mstu	114 5
+
+parj   	1  0.100
+parj   	2  0.300
+parj   	11 0.5 // Probability that a light meson (u/d quarks) has spin 1
+parj   	12 0.6 // Probability that a strange meson has spin 1
+parj   	21 0.40
+parj   	32 1.0
+parj   	33 0.80
+parj   	41 0.30
+parj   	42 0.58
+parj   	45 0.5
+
+ckin	1  1.
+ckin	2  -1.
+ckin   3  0.  // min parton pt
+ckin	4  -1. // max parton pt
+ckin	5  1.00
+ckin	6  1.00
+ckin	7  -10.
+ckin	8  10.
+ckin	9  -40.
+ckin	10  40.
+ckin	11  -40.
+ckin	12  40.
+ckin	13  -40.
+ckin	14  40.
+ckin	15  -40.
+ckin	16  40.
+ckin	17  -1.
+ckin	18  1.
+ckin	19  -1.
+ckin	20  1.
+ckin	21  0.
+ckin	22  1.
+ckin	23  0.
+ckin	24  1.
+ckin	25  -1.
+ckin	26  1.
+ckin	27  -1.
+ckin	28  1.
+ckin	31  2.
+ckin	32  -1.
+ckin	35  0.  // Q2 min
+ckin	36  -1.  // Q2 max
+ckin	37  0.
+ckin	38  -1.
+ckin	39  4.
+ckin	40  -1.
+ckin	65  10
+ckin	66  -1.
+ckin	67  0.
+ckin	68  -1.
+ckin	77  2.0
+ckin	78  -1.


### PR DESCRIPTION
 It's not calibrated to HERA data like the SIDIS config, but it
 doesn't require EICsmear to run, which can simplify using it
 for quick tests

(NOTE: it's not immediately needed for the simulations campaign)

Originally opened at https://github.com/ECCE-EIC/calibrations/pull/1, but Nico kindly pointed out that here would be more appropriate

@FriederikeBock @nschmidtALICE